### PR TITLE
Fixing link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ js-libp2p-tcp
 ![](https://raw.githubusercontent.com/diasdavid/abstract-connection/master/img/badge.png)
 ![](https://raw.githubusercontent.com/diasdavid/abstract-transport/master/img/badge.png)
 
-> Node.js implementation of the TCP module that libp2p uses, which implements the [interface-connection]() interface for dial/listen.
+> Node.js implementation of the TCP module that libp2p uses, which implements the [interface-connection](https://github.com/diasdavid/interface-connection) interface for dial/listen.
 
 note: libp2p-tcp in Node.js is a very thin shim that adds the support to dial to a `multiaddr`. This small shim will enable libp2p to use other different transports.


### PR DESCRIPTION
Added (what I think is) the correct link to the `interface-connection` repo.